### PR TITLE
Replace whatsmydns.net with nslookup.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ hubot>> example.com: <address>
 
 TIME PASSES...
 
-hubot>> DNS for example.com changed to <new-address>! See global propagation https://www.whatsmydns.net/#A/example.com
+hubot>> DNS for example.com changed to <new-address>! See global propagation https://www.nslookup.io/example.com
 
 user1>> hubot dns watch for something.example.com
 hubot>> I'll post to #current-chat-room when DNS for something.example.com changes from <address>

--- a/src/dns-watch.coffee
+++ b/src/dns-watch.coffee
@@ -25,7 +25,7 @@ checkDomain = (robot, domain, watcher) ->
   dns.lookup domain, (err, addresses, family) ->
     if addresses != watcher.address
       envelope = user: watcher.user_id, room: watcher.room
-      robot.send envelope, "@#{watcher.user_name} DNS for #{domain} changed to #{addresses}! See global propagation: https://www.whatsmydns.net/#A/#{domain}"
+      robot.send envelope, "@#{watcher.user_name} DNS for #{domain} changed to #{addresses}! See global propagation: https://www.nslookup.io/#{domain}"
       removeWatch robot, domain
 
 module.exports = (robot) ->


### PR DESCRIPTION
Changes the link to a DNS client with user tracking, a popup and 4 moving ads to one with 1 less intrusive ad, no tracking and more information.